### PR TITLE
Align Spring Cloud versions

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2025.0.0</spring-cloud.version>
+                <spring-cloud.version>2022.0.4</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>

--- a/service-discovery/pom.xml
+++ b/service-discovery/pom.xml
@@ -28,7 +28,7 @@
 	</scm>
 	<properties>
 		<java.version>17</java.version>
-		<spring-cloud.version>2025.0.0</spring-cloud.version>
+                <spring-cloud.version>2022.0.4</spring-cloud.version>
 	</properties>
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
## Summary
- align `spring-cloud.version` to `2022.0.4` in `api-gateway` and `service-discovery`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch maven binaries)*

------
https://chatgpt.com/codex/tasks/task_e_68407b7e6f388327af3368c0ad820d97