### PR TITLE
Fix cache eviction

### DIFF
--- a/user-microservice/src/main/java/com/example/user_microservice/UserService.java
+++ b/user-microservice/src/main/java/com/example/user_microservice/UserService.java
@@ -14,7 +14,7 @@ public class UserService {
     @Autowired
     private UserRepository userRepository;
 
-    @CacheEvict(value = "users", key = "#id")
+    @CacheEvict(value = "users", allEntries = true)
     public void deleteUserById(Long id) {
         userRepository.deleteById(id);
     }

--- a/user-microservice/src/test/java/com/example/user_microservice/UserCacheEvictIntegrationTests.java
+++ b/user-microservice/src/test/java/com/example/user_microservice/UserCacheEvictIntegrationTests.java
@@ -1,0 +1,47 @@
+package com.example.user_microservice;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "eureka.client.enabled=false"
+})
+class UserCacheEvictIntegrationTests {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        userRepository.deleteAll();
+        userRepository.save(new User(null, "John", "john@example.com"));
+    }
+
+    @Test
+    void deletingUserClearsCachedList() {
+        List<User> initial = userService.findAllUsersWithCache();
+        assertEquals(1, initial.size());
+
+        Long userId = initial.get(0).getId();
+        userService.deleteUserById(userId);
+
+        List<User> afterDeletion = userService.findAllUsersWithCache();
+        assertTrue(afterDeletion.isEmpty());
+    }
+}


### PR DESCRIPTION
## Summary
- evict entire `users` cache when deleting a user
- add integration test to verify that user deletion clears the cache

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_68407d36393c83279fa7cf732d11139d